### PR TITLE
Restructure YAML output to book/sheets/cells hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,32 @@ sheet-call-tree myfile.xlsx
 Output:
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5'
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: myfile.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5'
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
-Each formula cell becomes a top-level YAML key. Its value is the parsed AST of the
-formula, with constant cell references resolved to scalars and formula cell references
-shown as `@Sheet!Cell` strings (in the default `ref` mode).
+The output is grouped as `book → sheets → cells`. Each cell entry has a `cell` coordinate
+and a `formula` with the parsed AST. Constant cell references resolve to scalars; formula
+cell references appear as `@Sheet!Cell` strings (in the default `ref` mode).
 
 ## CLI flag overview
 

--- a/src/sheet_call_tree/cli.py
+++ b/src/sheet_call_tree/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
 from ._i18n import get_strings
 from .dependency_graph import build_dependency_graph, detect_cycles
@@ -60,9 +61,9 @@ def main(argv=None) -> int:
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as fh:
-            to_yaml(formula_cells, ref_mode=args.ref_mode, stream=fh)
+            to_yaml(formula_cells, ref_mode=args.ref_mode, book_name=Path(args.input).name, stream=fh)
     else:
-        print(to_yaml(formula_cells, ref_mode=args.ref_mode), end="")
+        print(to_yaml(formula_cells, ref_mode=args.ref_mode, book_name=Path(args.input).name), end="")
 
     return 0
 

--- a/src/sheet_call_tree/serializer.py
+++ b/src/sheet_call_tree/serializer.py
@@ -15,9 +15,15 @@ from .models import FunctionNode, RangeNode, RefNode
 _REF_MODES = {"ref", "ast", "value", "inline"}
 
 
+class _NoAliasDumper(yaml.Dumper):
+    def ignore_aliases(self, data):
+        return True
+
+
 def to_yaml(
     formula_cells: dict[str, object],
     ref_mode: str = "ref",
+    book_name: str = "",
     stream=None,
 ) -> str | None:
     """Convert a formula_cells dict to YAML.
@@ -26,6 +32,7 @@ def to_yaml(
         formula_cells: Mapping of cell ref strings to FunctionNode AST roots.
         ref_mode:      How to render formula-cell references.
                        One of 'ref' (default), 'ast', 'value', 'inline'.
+        book_name:     Workbook filename for the top-level 'book.name' field.
         stream:        Optional writable stream. If provided, YAML is written
                        there and None is returned. Otherwise the YAML string
                        is returned.
@@ -36,19 +43,35 @@ def to_yaml(
     if ref_mode not in _REF_MODES:
         raise ValueError(f"ref_mode must be one of {sorted(_REF_MODES)}, got {ref_mode!r}")
 
-    serialized: dict[str, object] = {}
-    for ref, node in formula_cells.items():
+    # Group cells by sheet name, preserving insertion order.
+    sheets: dict[str, list[dict]] = {}
+    for full_ref, node in formula_cells.items():
+        sheet, cell = full_ref.split("!", 1)
+        if sheet not in sheets:
+            sheets[sheet] = []
         if ref_mode == "inline":
-            serialized[ref] = _expr(node)
+            formula = _expr(node)
         else:
-            serialized[ref] = _to_dict(node, ref_mode)
+            formula = _to_dict(node, ref_mode)
+        sheets[sheet].append({"cell": cell, "formula": formula})
+
+    document = {
+        "book": {
+            "name": book_name,
+            "sheets": [
+                {"name": sheet_name, "cells": cells}
+                for sheet_name, cells in sheets.items()
+            ],
+        }
+    }
 
     return yaml.dump(
-        serialized,
+        document,
+        Dumper=_NoAliasDumper,
         stream=stream,
         default_flow_style=False,
         allow_unicode=True,
-        sort_keys=True,
+        sort_keys=False,
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,14 +7,25 @@ from sheet_call_tree.reader import extract_formula_cells
 from sheet_call_tree.serializer import to_yaml
 
 
+def _get_cell(parsed, sheet, cell):
+    """Return the formula dict for a given sheet+cell from parsed YAML."""
+    s = next(s for s in parsed["book"]["sheets"] if s["name"] == sheet)
+    return next(c["formula"] for c in s["cells"] if c["cell"] == cell)
+
+
 def test_yaml_output_structure(simple_workbook_path):
     cells = extract_formula_cells(simple_workbook_path)
     output = to_yaml(cells)
     parsed = yaml.safe_load(output)
 
-    assert "Sheet1!C5" in parsed
-    assert "Sheet1!B10" in parsed
-    assert "Sheet1!B11" in parsed
+    assert "book" in parsed
+    sheet_names = [s["name"] for s in parsed["book"]["sheets"]]
+    assert "Sheet1" in sheet_names
+    s1_cells = next(s["cells"] for s in parsed["book"]["sheets"] if s["name"] == "Sheet1")
+    cell_ids = [c["cell"] for c in s1_cells]
+    assert "C5" in cell_ids
+    assert "B10" in cell_ids
+    assert "B11" in cell_ids
 
 
 def test_c5_is_sum_node(simple_workbook_path):
@@ -56,7 +67,9 @@ def test_cli_stdout(simple_workbook_path, capsys):
     assert rc == 0
     captured = capsys.readouterr()
     parsed = yaml.safe_load(captured.out)
-    assert "Sheet1!C5" in parsed
+    assert "book" in parsed
+    cell_ids = [c["cell"] for s in parsed["book"]["sheets"] for c in s["cells"]]
+    assert "C5" in cell_ids
 
 
 def test_cli_filter(simple_workbook_path, capsys):
@@ -64,7 +77,8 @@ def test_cli_filter(simple_workbook_path, capsys):
     assert rc == 0
     captured = capsys.readouterr()
     parsed = yaml.safe_load(captured.out)
-    assert list(parsed.keys()) == ["Sheet1!C5"]
+    s1_cells = next(s["cells"] for s in parsed["book"]["sheets"] if s["name"] == "Sheet1")
+    assert [c["cell"] for c in s1_cells] == ["C5"]
 
 
 def test_cli_output_file(simple_workbook_path, tmp_path):
@@ -72,7 +86,8 @@ def test_cli_output_file(simple_workbook_path, tmp_path):
     rc = main([str(simple_workbook_path), "--output", str(out)])
     assert rc == 0
     parsed = yaml.safe_load(out.read_text())
-    assert "Sheet1!C5" in parsed
+    cell_ids = [c["cell"] for s in parsed["book"]["sheets"] for c in s["cells"]]
+    assert "C5" in cell_ids
 
 
 def test_cli_filter_missing_cell(simple_workbook_path, capsys):
@@ -92,7 +107,7 @@ class TestRefModeRef:
         output = to_yaml(cells, ref_mode="ref")
         parsed = yaml.safe_load(output)
         # C5 = SUM(A1:A2); A1=10, A2=20 are constants → scalars in RANGE
-        c5 = parsed["Sheet1!C5"]
+        c5 = _get_cell(parsed, "Sheet1", "C5")
         assert c5 == {"SUM": [{"RANGE": [10, 20]}]}
 
     def test_formula_refs_as_at_strings(self, simple_workbook_path):
@@ -100,14 +115,15 @@ class TestRefModeRef:
         output = to_yaml(cells, ref_mode="ref")
         parsed = yaml.safe_load(output)
         # B10 = C5+1.1; C5 is a formula cell → '@Sheet1!C5'
-        b10 = parsed["Sheet1!B10"]
+        b10 = _get_cell(parsed, "Sheet1", "B10")
         assert b10 == {"ADD": ["@Sheet1!C5", 1.1]}
 
     def test_cli_default_is_ref(self, simple_workbook_path, capsys):
         rc = main([str(simple_workbook_path), "--filter", "Sheet1!B10"])
         assert rc == 0
         parsed = yaml.safe_load(capsys.readouterr().out)
-        assert parsed["Sheet1!B10"] == {"ADD": ["@Sheet1!C5", 1.1]}
+        b10 = _get_cell(parsed, "Sheet1", "B10")
+        assert b10 == {"ADD": ["@Sheet1!C5", 1.1]}
 
 
 class TestRefModeAst:
@@ -117,7 +133,7 @@ class TestRefModeAst:
         cells = extract_formula_cells(simple_workbook_path)
         output = to_yaml(cells, ref_mode="ast")
         parsed = yaml.safe_load(output)
-        b10 = parsed["Sheet1!B10"]
+        b10 = _get_cell(parsed, "Sheet1", "B10")
         # Should have ADD with '@Sheet1!C5' mapped to its expanded AST
         assert "ADD" in b10
         args = b10["ADD"]
@@ -129,14 +145,14 @@ class TestRefModeAst:
         cells = extract_formula_cells(simple_workbook_path)
         output = to_yaml(cells, ref_mode="ast")
         parsed = yaml.safe_load(output)
-        c5 = parsed["Sheet1!C5"]
+        c5 = _get_cell(parsed, "Sheet1", "C5")
         assert c5 == {"SUM": [{"RANGE": [10, 20]}]}
 
     def test_cli_ast_mode(self, simple_workbook_path, capsys):
         rc = main([str(simple_workbook_path), "--filter", "Sheet1!B10", "--ref-mode", "ast"])
         assert rc == 0
         parsed = yaml.safe_load(capsys.readouterr().out)
-        b10 = parsed["Sheet1!B10"]
+        b10 = _get_cell(parsed, "Sheet1", "B10")
         args = b10["ADD"]
         assert any(isinstance(a, dict) and "@Sheet1!C5" in a for a in args)
 
@@ -149,7 +165,7 @@ class TestRefModeValue:
         output = to_yaml(cells, ref_mode="value")
         parsed = yaml.safe_load(output)
         # A1 and A2 are constants → scalars in RANGE regardless of mode
-        c5 = parsed["Sheet1!C5"]
+        c5 = _get_cell(parsed, "Sheet1", "C5")
         assert c5 == {"SUM": [{"RANGE": [10, 20]}]}
 
     def test_formula_ref_is_none_for_programmatic_xlsx(self, simple_workbook_path):
@@ -157,7 +173,7 @@ class TestRefModeValue:
         cells = extract_formula_cells(simple_workbook_path)
         output = to_yaml(cells, ref_mode="value")
         parsed = yaml.safe_load(output)
-        b10 = parsed["Sheet1!B10"]
+        b10 = _get_cell(parsed, "Sheet1", "B10")
         # C5 is a formula cell with no cached value → null
         assert b10 == {"ADD": [None, 1.1]}
 
@@ -165,7 +181,8 @@ class TestRefModeValue:
         rc = main([str(simple_workbook_path), "--filter", "Sheet1!C5", "--ref-mode", "value"])
         assert rc == 0
         parsed = yaml.safe_load(capsys.readouterr().out)
-        assert "Sheet1!C5" in parsed
+        c5 = _get_cell(parsed, "Sheet1", "C5")
+        assert c5 is not None
 
 
 class TestRefModeInline:
@@ -175,23 +192,23 @@ class TestRefModeInline:
         cells = extract_formula_cells(simple_workbook_path)
         output = to_yaml(cells, ref_mode="inline")
         parsed = yaml.safe_load(output)
-        assert parsed["Sheet1!C5"] == "SUM(RANGE(10, 20))"
+        assert _get_cell(parsed, "Sheet1", "C5") == "SUM(RANGE(10, 20))"
 
     def test_b10_inline_expands_c5(self, simple_workbook_path):
         cells = extract_formula_cells(simple_workbook_path)
         output = to_yaml(cells, ref_mode="inline")
         parsed = yaml.safe_load(output)
-        assert parsed["Sheet1!B10"] == "ADD(SUM(RANGE(10, 20)), 1.1)"
+        assert _get_cell(parsed, "Sheet1", "B10") == "ADD(SUM(RANGE(10, 20)), 1.1)"
 
     def test_b11_inline_expands_c5(self, simple_workbook_path):
         cells = extract_formula_cells(simple_workbook_path)
         output = to_yaml(cells, ref_mode="inline")
         parsed = yaml.safe_load(output)
-        assert parsed["Sheet1!B11"] == "MUL(SUM(RANGE(10, 20)), 2)"
+        assert _get_cell(parsed, "Sheet1", "B11") == "MUL(SUM(RANGE(10, 20)), 2)"
 
     def test_cli_inline_mode(self, simple_workbook_path, capsys):
         rc = main([str(simple_workbook_path), "--ref-mode", "inline"])
         assert rc == 0
         parsed = yaml.safe_load(capsys.readouterr().out)
-        assert parsed["Sheet1!C5"] == "SUM(RANGE(10, 20))"
-        assert parsed["Sheet1!B10"] == "ADD(SUM(RANGE(10, 20)), 1.1)"
+        assert _get_cell(parsed, "Sheet1", "C5") == "SUM(RANGE(10, 20))"
+        assert _get_cell(parsed, "Sheet1", "B10") == "ADD(SUM(RANGE(10, 20)), 1.1)"

--- a/user_manuals/ja/output-formats.md
+++ b/user_manuals/ja/output-formats.md
@@ -25,22 +25,30 @@ sheet-call-tree example.xlsx
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5'
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5'
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
-`Sheet1!B10` は `ADD` を 2 つの引数で呼び出しています：数式セル `Sheet1!C5` への参照と定数 `1.1` です。`Sheet1!C5` はフル AST を持つ独立したトップレベルエントリとして現れます。
+`B10` は `ADD` を 2 つの引数で呼び出しています：数式セル `Sheet1!C5` への参照と定数 `1.1` です。`C5` はフル AST を持つ独立した `cells` エントリとして現れます。
 
 ---
 
@@ -55,30 +63,38 @@ sheet-call-tree example.xlsx --ref-mode ast
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
-`@Sheet1!C5` キーはフルの `SUM(RANGE(10, 20))` サブツリーを値として持ち、別のエントリにジャンプすることなく `Sheet1!B10` と `Sheet1!B11` の中で直接確認できます。
+`@Sheet1!C5` キーはフルの `SUM(RANGE(10, 20))` サブツリーを値として持ち、別のエントリにジャンプすることなく `B10` と `B11` の中で直接確認できます。
 
 ---
 
@@ -93,19 +109,27 @@ sheet-call-tree example.xlsx --ref-mode value
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - null
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - null
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - null
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - null
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 `Sheet1!C5` 参照の `null` 値は、サンプルワークブックがプログラムで作成されており、キャッシュ済みの数式結果がないために現れます。Excel で保存されたワークブックでは、ここに実際のスカラー値が入ります。
@@ -123,12 +147,20 @@ sheet-call-tree example.xlsx --ref-mode inline
 ```
 
 ```yaml
-Sheet1!B10: ADD(SUM(RANGE(10, 20)), 1.1)
-Sheet1!B11: MUL(SUM(RANGE(10, 20)), 2)
-Sheet1!C5: SUM(RANGE(10, 20))
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula: ADD(SUM(RANGE(10, 20)), 1.1)
+    - cell: B11
+      formula: MUL(SUM(RANGE(10, 20)), 2)
+    - cell: C5
+      formula: SUM(RANGE(10, 20))
 ```
 
-`Sheet1!C5` は `Sheet1!B10` と `Sheet1!B11` に完全にインライン展開されていることに注意してください — `ADD(SUM(RANGE(10, 20)), 1.1)` — 名前で参照されるのではなく直接埋め込まれています。
+`C5` は `B10` と `B11` に完全にインライン展開されていることに注意してください — `ADD(SUM(RANGE(10, 20)), 1.1)` — 名前で参照されるのではなく直接埋め込まれています。
 
 ---
 

--- a/user_manuals/ja/quickstart.md
+++ b/user_manuals/ja/quickstart.md
@@ -36,29 +36,36 @@ sheet-call-tree example.xlsx
 出力（デフォルトの `ref` モード）：
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5'
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5'
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 **出力の読み方：**
 
-- トップレベルのキー（`Sheet1!B10`、`Sheet1!B11`、`Sheet1!C5`）は数式セルです。
-- 値はそのセルの数式の解析済み AST です。
+- トップレベルの `book` キーがワークブックとシートでセルをグループ化します。
+- `cells` の各エントリには `cell` 座標（`B10`、`C5` など）と `formula` AST があります。
 - `ADD`、`MUL`、`SUM` は解析されたオペレーター/関数で、その引数は YAML のリストです。
 - `RANGE: [10, 20]` は `A1:A2` を表し、両端点がスカラー値に解決されています。
 - `'@Sheet1!C5'` は別の数式セルへのクロスリファレンスです。`@` プレフィックスにより通常の文字列と区別されます。
-- 出力キーはアルファベット順にソートされています（`Sheet1!B10` < `Sheet1!B11` < `Sheet1!C5`）。
 
 ## 3. 単一セルを詳しく調べる
 
@@ -69,10 +76,16 @@ sheet-call-tree example.xlsx --filter Sheet1!B10
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
 ```
 
 ## 4. フル AST をインラインで展開する（`--ref-mode ast`）
@@ -84,27 +97,35 @@ sheet-call-tree example.xlsx --ref-mode ast
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 `@Sheet1!C5` キーにはフルのサブツリーが値として付加されており、別のエントリにジャンプすることなく完全な依存関係をインラインで読めます。
@@ -118,9 +139,17 @@ sheet-call-tree example.xlsx --ref-mode inline
 ```
 
 ```yaml
-Sheet1!B10: ADD(SUM(RANGE(10, 20)), 1.1)
-Sheet1!B11: MUL(SUM(RANGE(10, 20)), 2)
-Sheet1!C5: SUM(RANGE(10, 20))
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula: ADD(SUM(RANGE(10, 20)), 1.1)
+    - cell: B11
+      formula: MUL(SUM(RANGE(10, 20)), 2)
+    - cell: C5
+      formula: SUM(RANGE(10, 20))
 ```
 
 コメントやチケットへの貼り付け、または素早い人間による読み取りに便利です。

--- a/user_manuals/output-formats.md
+++ b/user_manuals/output-formats.md
@@ -31,23 +31,31 @@ sheet-call-tree example.xlsx
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5'
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5'
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
-`Sheet1!B10` calls `ADD` with two arguments: a reference to the formula cell `Sheet1!C5`
-and the constant `1.1`. `Sheet1!C5` appears as its own top-level entry with its full AST.
+`B10` calls `ADD` with two arguments: a reference to the formula cell `Sheet1!C5`
+and the constant `1.1`. `C5` appears as its own `cells` entry with its full AST.
 
 ---
 
@@ -65,31 +73,39 @@ sheet-call-tree example.xlsx --ref-mode ast
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 The `@Sheet1!C5` key carries its full `SUM(RANGE(10, 20))` sub-tree as its value,
-visible directly inside `Sheet1!B10` and `Sheet1!B11` without jumping to another entry.
+visible directly inside `B10` and `B11` without jumping to another entry.
 
 ---
 
@@ -108,19 +124,27 @@ sheet-call-tree example.xlsx --ref-mode value
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - null
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - null
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - null
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - null
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 The `null` values for `Sheet1!C5` refs appear because the example workbook was created
@@ -143,12 +167,20 @@ sheet-call-tree example.xlsx --ref-mode inline
 ```
 
 ```yaml
-Sheet1!B10: ADD(SUM(RANGE(10, 20)), 1.1)
-Sheet1!B11: MUL(SUM(RANGE(10, 20)), 2)
-Sheet1!C5: SUM(RANGE(10, 20))
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula: ADD(SUM(RANGE(10, 20)), 1.1)
+    - cell: B11
+      formula: MUL(SUM(RANGE(10, 20)), 2)
+    - cell: C5
+      formula: SUM(RANGE(10, 20))
 ```
 
-Note that `Sheet1!C5` is fully inlined into `Sheet1!B10` and `Sheet1!B11` —
+Note that `C5` is fully inlined into `B10` and `B11` —
 `ADD(SUM(RANGE(10, 20)), 1.1)` — rather than referenced by name.
 
 ---

--- a/user_manuals/quickstart.md
+++ b/user_manuals/quickstart.md
@@ -37,30 +37,37 @@ sheet-call-tree example.xlsx
 Output (default `ref` mode):
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5'
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5'
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 **Reading the output:**
 
-- Each top-level key (`Sheet1!B10`, `Sheet1!B11`, `Sheet1!C5`) is a formula cell.
-- The value is the parsed AST of that cell's formula.
+- The top-level `book` key groups cells by workbook and sheet.
+- Each entry in `cells` has a `cell` coordinate (`B10`, `C5`, …) and a `formula` AST.
 - `ADD`, `MUL`, `SUM` are the parsed operators/functions; their arguments are YAML lists.
 - `RANGE: [10, 20]` represents `A1:A2` with both endpoints resolved to their scalar values.
 - `'@Sheet1!C5'` is a cross-reference to another formula cell. The `@` prefix distinguishes
   formula-cell refs from plain strings.
-- Output keys are sorted alphabetically (`Sheet1!B10` < `Sheet1!B11` < `Sheet1!C5`).
 
 ## 3. Drill into a single cell
 
@@ -71,10 +78,16 @@ sheet-call-tree example.xlsx --filter Sheet1!B10
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5'
-  - 1.1
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5'
+        - 1.1
 ```
 
 ## 4. Expand the full AST inline (`--ref-mode ast`)
@@ -87,27 +100,35 @@ sheet-call-tree example.xlsx --ref-mode ast
 ```
 
 ```yaml
-Sheet1!B10:
-  ADD:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 1.1
-Sheet1!B11:
-  MUL:
-  - '@Sheet1!C5':
-      SUM:
-      - RANGE:
-        - 10
-        - 20
-  - 2
-Sheet1!C5:
-  SUM:
-  - RANGE:
-    - 10
-    - 20
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula:
+        ADD:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 1.1
+    - cell: B11
+      formula:
+        MUL:
+        - '@Sheet1!C5':
+            SUM:
+            - RANGE:
+              - 10
+              - 20
+        - 2
+    - cell: C5
+      formula:
+        SUM:
+        - RANGE:
+          - 10
+          - 20
 ```
 
 The `@Sheet1!C5` key now carries its full sub-tree as its value, so you can read the
@@ -122,9 +143,17 @@ sheet-call-tree example.xlsx --ref-mode inline
 ```
 
 ```yaml
-Sheet1!B10: ADD(SUM(RANGE(10, 20)), 1.1)
-Sheet1!B11: MUL(SUM(RANGE(10, 20)), 2)
-Sheet1!C5: SUM(RANGE(10, 20))
+book:
+  name: example.xlsx
+  sheets:
+  - name: Sheet1
+    cells:
+    - cell: B10
+      formula: ADD(SUM(RANGE(10, 20)), 1.1)
+    - cell: B11
+      formula: MUL(SUM(RANGE(10, 20)), 2)
+    - cell: C5
+      formula: SUM(RANGE(10, 20))
 ```
 
 This is useful for quick human reading or for pasting into comments/tickets.


### PR DESCRIPTION
## Summary

- Output is now grouped as `book → sheets[] → cells[]` instead of a flat mapping of fully-qualified refs
- Cell coordinate uses `cell:` field (e.g. `cell: B10`) to avoid confusion with formula cross-references (`@Sheet1!C5`)
- `_NoAliasDumper` suppresses PyYAML anchor/alias generation when the same object appears in multiple places
- `to_yaml` gains a `book_name` parameter; CLI passes the input filename via `Path(args.input).name`

## Test plan

- [x] `pytest -q` → 69 passed
- [x] `sheet-call-tree <file.xlsx>` produces `book: / sheets: / cells:` structure
- [x] `--filter` narrows to a single cell entry within the sheet
- [x] All four `--ref-mode` values render correctly under the new structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)